### PR TITLE
Add package gettext

### DIFF
--- a/aws-deployer/Dockerfile
+++ b/aws-deployer/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-alpine3.8
 
 RUN apk --no-cache update && \
-    apk --no-cache add ca-certificates groff less jq bash && \
+    apk --no-cache add ca-certificates groff less jq bash gettext && \
     pip --no-cache-dir install awscli && \
     rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
The package gettext is a good replacement for the "Replace Token" available in TFS Release Defitions.
We use the command envsubst for that.

For example if you have a file `config.release.json`:
```json
{
    "DbConnectionString": "${ConnectionString}"
}
```
During your deployment  you can use envsubst in order to replace variables in that file in the following manner:
```bash
export ConnectionString="server=localhost;userid=root;pwd=root;port=3306;database=myDb;"
envsubst < config.release.json > config.json
```
PS: In GitLab the export command is not needed

That will give you the output in file named `config.json`:
```json
{
    "DbConnectionString": "server=localhost;userid=root;pwd=root;port=3306;database=myDb;"
}
```